### PR TITLE
Feature: port Amadevus/pwsh-script module

### DIFF
--- a/GitHubActions/GitHubActions.psd1
+++ b/GitHubActions/GitHubActions.psd1
@@ -46,12 +46,16 @@
     ## Functions to export from this module
     FunctionsToExport = @(
         ,'Add-ActionPath'
-        ,'Add-ActionSecretMask'
+        ,'Add-ActionSecret'
         ,'Enter-ActionOutputGroup'
         ,'Exit-ActionOutputGroup'
         ,'Get-ActionInput'
         ,'Get-ActionInputs'
-        ,'Invoke-ActionWithinOutputGroup'
+        ,'Get-ActionIsDebug'
+        ,'Invoke-ActionGroup'
+        ,'Invoke-ActionNoCommandsBlock'
+        ,'Send-ActionCommand'
+        ,'Set-ActionCommandEcho'
         ,'Set-ActionFailed'
         ,'Set-ActionOutput'
         ,'Set-ActionVariable'

--- a/docs/GitHubActions/Add-ActionPath.md
+++ b/docs/GitHubActions/Add-ActionPath.md
@@ -6,6 +6,7 @@ NAME
     
 SYNOPSIS
     Prepends path to the PATH (for this action and future actions).
+    Equivalent of `core.addPath(path)`.
     
     
 SYNTAX
@@ -47,6 +48,7 @@ OUTPUTS
     
 RELATED LINKS
     https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#adding-a-system-path
+    https://github.com/actions/toolkit/tree/7f7e22a9406f546f9084e9eb7a4e541a3563f92b/packages/core#path-manipulation
 
 ```
 

--- a/docs/GitHubActions/Add-ActionSecret.md
+++ b/docs/GitHubActions/Add-ActionSecret.md
@@ -1,15 +1,16 @@
-# Add-ActionSecretMask
+# Add-ActionSecret
 ```
 
 NAME
-    Add-ActionSecretMask
+    Add-ActionSecret
     
 SYNOPSIS
     Registers a secret which will get masked from logs.
+    Equivalent of `core.setSecret(secret)`.
     
     
 SYNTAX
-    Add-ActionSecretMask [-Secret] <String> [<CommonParameters>]
+    Add-ActionSecret [-Secret] <String> [<CommonParameters>]
     
     
 DESCRIPTION
@@ -37,6 +38,8 @@ OUTPUTS
     
     
 RELATED LINKS
+    https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#masking-a-value-in-log
+    https://github.com/actions/toolkit/tree/7f7e22a9406f546f9084e9eb7a4e541a3563f92b/packages/core#setting-a-secret
 
 ```
 

--- a/docs/GitHubActions/Enter-ActionOutputGroup.md
+++ b/docs/GitHubActions/Enter-ActionOutputGroup.md
@@ -6,6 +6,8 @@ NAME
     
 SYNOPSIS
     Begin an output group.
+    Output until the next `groupEnd` will be foldable in this group.
+    Equivalent of `core.startGroup(name)`.
     
     
 SYNTAX
@@ -18,7 +20,7 @@ DESCRIPTION
 
 PARAMETERS
     -Name <String>
-        Name of the output group.
+        The name of the output group.
         
         Required?                    true
         Position?                    1
@@ -38,7 +40,8 @@ OUTPUTS
     
     
 RELATED LINKS
-    https://github.com/actions/toolkit/tree/a6e72497764b1cf53192eb720f551d7f0db3a4b4/packages/core#logging
+    https://github.com/actions/toolkit/blob/7f7e22a9406f546f9084e9eb7a4e541a3563f92b/docs/commands.md#group-and-ungroup-log-lines
+    https://github.com/actions/toolkit/tree/7f7e22a9406f546f9084e9eb7a4e541a3563f92b/packages/core#logging
 
 ```
 

--- a/docs/GitHubActions/Get-ActionInput.md
+++ b/docs/GitHubActions/Get-ActionInput.md
@@ -5,7 +5,8 @@ NAME
     Get-ActionInput
     
 SYNOPSIS
-    Gets the value of an input.  The value is also trimmed.
+    Gets the value of an input. The value is also trimmed.
+    Equivalent of `core.getInput(name)`.
     
     
 SYNTAX
@@ -17,7 +18,7 @@ DESCRIPTION
 
 PARAMETERS
     -Name <String>
-        Name of the input to get
+        Name of the input to get.
         
         Required?                    true
         Position?                    1
@@ -43,10 +44,13 @@ PARAMETERS
 INPUTS
     
 OUTPUTS
+    System.String
+    
     
     
 RELATED LINKS
-    https://github.com/actions/toolkit/tree/a6e72497764b1cf53192eb720f551d7f0db3a4b4/packages/core#inputsoutputs
+    https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepswith
+    https://github.com/actions/toolkit/tree/7f7e22a9406f546f9084e9eb7a4e541a3563f92b/packages/core#inputsoutputs
 
 ```
 

--- a/docs/GitHubActions/Get-ActionInputs.md
+++ b/docs/GitHubActions/Get-ActionInputs.md
@@ -6,6 +6,7 @@ NAME
     
 SYNOPSIS
     Returns a map of all the available inputs and their values.
+    No quivalent in `@actions/core` package.
     
     
 SYNTAX
@@ -30,7 +31,8 @@ OUTPUTS
     
     
 RELATED LINKS
-    https://github.com/actions/toolkit/tree/a6e72497764b1cf53192eb720f551d7f0db3a4b4/packages/core#inputsoutputs
+    https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepswith
+    https://github.com/actions/toolkit/tree/7f7e22a9406f546f9084e9eb7a4e541a3563f92b/packages/core#inputsoutputs
 
 ```
 

--- a/docs/GitHubActions/Get-ActionIsDebug.md
+++ b/docs/GitHubActions/Get-ActionIsDebug.md
@@ -1,16 +1,16 @@
-# Exit-ActionOutputGroup
+# Get-ActionIsDebug
 ```
 
 NAME
-    Exit-ActionOutputGroup
+    Get-ActionIsDebug
     
 SYNOPSIS
-    End an output group.
-    Equivalent of `core.endGroup()`.
+    Gets whether Actions Step Debug is on or not.
+    Equivalent of `core.isDebug()`.
     
     
 SYNTAX
-    Exit-ActionOutputGroup [<CommonParameters>]
+    Get-ActionIsDebug [<CommonParameters>]
     
     
 DESCRIPTION
@@ -26,10 +26,12 @@ PARAMETERS
 INPUTS
     
 OUTPUTS
+    System.Boolean
+    
     
     
 RELATED LINKS
-    https://github.com/actions/toolkit/blob/7f7e22a9406f546f9084e9eb7a4e541a3563f92b/docs/commands.md#group-and-ungroup-log-lines
+    https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#using-workflow-commands-to-access-toolkit-functions
     https://github.com/actions/toolkit/tree/7f7e22a9406f546f9084e9eb7a4e541a3563f92b/packages/core#logging
 
 ```

--- a/docs/GitHubActions/Invoke-ActionGroup.md
+++ b/docs/GitHubActions/Invoke-ActionGroup.md
@@ -1,15 +1,16 @@
-# Invoke-ActionWithinOutputGroup
+# Invoke-ActionGroup
 ```
 
 NAME
-    Invoke-ActionWithinOutputGroup
+    Invoke-ActionGroup
     
 SYNOPSIS
     Executes the argument script block within an output group.
+    Equivalent of `core.group(name, func)`.
     
     
 SYNTAX
-    Invoke-ActionWithinOutputGroup [-Name] <String> [-ScriptBlock] <ScriptBlock> [<CommonParameters>]
+    Invoke-ActionGroup [-Name] <String> [-ScriptBlock] <ScriptBlock> [<CommonParameters>]
     
     
 DESCRIPTION
@@ -46,7 +47,8 @@ OUTPUTS
     
     
 RELATED LINKS
-    https://github.com/actions/toolkit/tree/a6e72497764b1cf53192eb720f551d7f0db3a4b4/packages/core#logging
+    https://github.com/actions/toolkit/blob/7f7e22a9406f546f9084e9eb7a4e541a3563f92b/docs/commands.md#group-and-ungroup-log-lines
+    https://github.com/actions/toolkit/tree/7f7e22a9406f546f9084e9eb7a4e541a3563f92b/packages/core#logging
 
 ```
 

--- a/docs/GitHubActions/Invoke-ActionNoCommandsBlock.md
+++ b/docs/GitHubActions/Invoke-ActionNoCommandsBlock.md
@@ -1,24 +1,27 @@
-# Set-ActionVariable
+# Invoke-ActionNoCommandsBlock
 ```
 
 NAME
-    Set-ActionVariable
+    Invoke-ActionNoCommandsBlock
     
 SYNOPSIS
-    Sets env variable for this action and future actions in the job.
-    Equivalent of `core.exportVariable(name, value)`.
+    Invokes a scriptblock that won't result in any output interpreted as a workflow command.
+    Useful for printing arbitrary text that may contain command-like text.
+    No quivalent in `@actions/core` package.
     
     
 SYNTAX
-    Set-ActionVariable [-Name] <String> [-Value] <Object> [-SkipLocal] [<CommonParameters>]
+    Invoke-ActionNoCommandsBlock [-EndToken] <String> [-ScriptBlock] <ScriptBlock> [<CommonParameters>]
+    
+    Invoke-ActionNoCommandsBlock [-ScriptBlock] <ScriptBlock> -GenerateToken [<CommonParameters>]
     
     
 DESCRIPTION
     
 
 PARAMETERS
-    -Name <String>
-        The name of the variable to set.
+    -EndToken <String>
+        String token to stop workflow commands, used after scriptblock to start workflow commands back.
         
         Required?                    true
         Position?                    1
@@ -26,8 +29,8 @@ PARAMETERS
         Accept pipeline input?       false
         Accept wildcard characters?  false
         
-    -Value <Object>
-        The value of the variable. Non-string values will be converted to a string via ConvertTo-Json.
+    -ScriptBlock <ScriptBlock>
+        Script block to invoke within a no-commands context.
         
         Required?                    true
         Position?                    2
@@ -35,10 +38,10 @@ PARAMETERS
         Accept pipeline input?       false
         Accept wildcard characters?  false
         
-    -SkipLocal [<SwitchParameter>]
-        Do not set variable in current action's/step's environment.
+    -GenerateToken [<SwitchParameter>]
+        Use this to automatically generate a GUID and use it as the EndToken.
         
-        Required?                    false
+        Required?                    true
         Position?                    named
         Default value                False
         Accept pipeline input?       false
@@ -56,8 +59,7 @@ OUTPUTS
     
     
 RELATED LINKS
-    https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
-    https://github.com/actions/toolkit/tree/7f7e22a9406f546f9084e9eb7a4e541a3563f92b/packages/core#exporting-variables
+    https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#stopping-and-starting-workflow-commands
 
 ```
 

--- a/docs/GitHubActions/README.md
+++ b/docs/GitHubActions/README.md
@@ -1,23 +1,26 @@
-
 # GitHubActions _(0.7.0)_
 Supports interacting with Github Actions environment
 | Cmdlet | Synopsis |
 |-|-|
-| [Add-ActionPath](Add-ActionPath.md) | Prepends path to the PATH (for this action and future actions). |
-| [Add-ActionSecretMask](Add-ActionSecretMask.md) | Registers a secret which will get masked from logs. |
-| [Enter-ActionOutputGroup](Enter-ActionOutputGroup.md) | Begin an output group. |
-| [Exit-ActionOutputGroup](Exit-ActionOutputGroup.md) | End an output group. |
+| [Add-ActionPath](Add-ActionPath.md) | Prepends path to the PATH (for this action and future actions).<br/>Equivalent of `core.addPath(path)`. |
+| [Add-ActionSecret](Add-ActionSecret.md) | Registers a secret which will get masked from logs.<br/>Equivalent of `core.setSecret(secret)`. |
+| [Enter-ActionOutputGroup](Enter-ActionOutputGroup.md) | Begin an output group.<br/>Output until the next `groupEnd` will be foldable in this group.<br/>Equivalent of `core.startGroup(name)`. |
+| [Exit-ActionOutputGroup](Exit-ActionOutputGroup.md) | End an output group.<br/>Equivalent of `core.endGroup()`. |
 | [Get-ActionContext](Get-ActionContext.md) | Returns details of the executing GitHub Workflow assembled from the environment. |
-| [Get-ActionInput](Get-ActionInput.md) | Gets the value of an input.  The value is also trimmed. |
-| [Get-ActionInputs](Get-ActionInputs.md) | Returns a map of all the available inputs and their values. |
+| [Get-ActionInput](Get-ActionInput.md) | Gets the value of an input. The value is also trimmed.<br/>Equivalent of `core.getInput(name)`. |
+| [Get-ActionInputs](Get-ActionInputs.md) | Returns a map of all the available inputs and their values.<br/>No quivalent in `@actions/core` package. |
+| [Get-ActionIsDebug](Get-ActionIsDebug.md) | Gets whether Actions Step Debug is on or not.<br/>Equivalent of `core.isDebug()`. |
 | [Get-ActionIssue](Get-ActionIssue.md) | Returns details of the issue associated with the workflow trigger,<br/>including owner and repo name, and the issue (or PR) number. |
 | [Get-ActionRepo](Get-ActionRepo.md) | Returns details of the repository, including owner and repo name. |
-| [Invoke-ActionWithinOutputGroup](Invoke-ActionWithinOutputGroup.md) | Executes the argument script block within an output group. |
-| [Set-ActionFailed](Set-ActionFailed.md) | Used as a shortcut for `Write-ActionError` and `exit 1` |
-| [Set-ActionOutput](Set-ActionOutput.md) | Sets the value of an output. |
-| [Set-ActionVariable](Set-ActionVariable.md) | Sets env variable for this action and future actions in the job. |
-| [Write-ActionDebug](Write-ActionDebug.md) | Writes debug message to user log. |
-| [Write-ActionError](Write-ActionError.md) | Adds an error issue. |
-| [Write-ActionInfo](Write-ActionInfo.md) | Writes info to log with console.log. |
-| [Write-ActionWarning](Write-ActionWarning.md) | Adds a warning issue. |
+| [Invoke-ActionGroup](Invoke-ActionGroup.md) | Executes the argument script block within an output group.<br/>Equivalent of `core.group(name, func)`. |
+| [Invoke-ActionNoCommandsBlock](Invoke-ActionNoCommandsBlock.md) | Invokes a scriptblock that won't result in any output interpreted as a workflow command.<br/>Useful for printing arbitrary text that may contain command-like text.<br/>No quivalent in `@actions/core` package. |
+| [Send-ActionCommand](Send-ActionCommand.md) | Sends a command to the hosting Workflow/Action context.<br/>Equivalent to `core.issue(cmd, msg)`/`core.issueCommand(cmd, props, msg)`. |
+| [Set-ActionCommandEcho](Set-ActionCommandEcho.md) | Enables or disables the echoing of commands into stdout for the rest of the step.<br/>Echoing is disabled by default if ACTIONS_STEP_DEBUG is not set.<br/>Equivalent of `core.setCommandEcho(enabled)`. |
+| [Set-ActionFailed](Set-ActionFailed.md) | Sets an action status to failed.<br/>When the action exits it will be with an exit code of 1.<br/>Equivalent of `core.setFailed(message)`. |
+| [Set-ActionOutput](Set-ActionOutput.md) | Sets the value of an output.<br/>Equivalent of `core.setOutput(name, value)`. |
+| [Set-ActionVariable](Set-ActionVariable.md) | Sets env variable for this action and future actions in the job.<br/>Equivalent of `core.exportVariable(name, value)`. |
+| [Write-ActionDebug](Write-ActionDebug.md) | Writes debug message to user log.<br/>Equivalent of `core.debug(message)`. |
+| [Write-ActionError](Write-ActionError.md) | Adds an error issue.<br/>Equivalent of `core.error(message)`. |
+| [Write-ActionInfo](Write-ActionInfo.md) | Writes info to log with console.log.<br/>Equivalent of `core.info(message)`.<br/>Forwards to Write-Host. |
+| [Write-ActionWarning](Write-ActionWarning.md) | Adds a warning issue.<br/>Equivalent of `core.warning(message)`. |
 ###### Copyright (C) Eugene Bekker.  All rights reserved.

--- a/docs/GitHubActions/Send-ActionCommand.md
+++ b/docs/GitHubActions/Send-ActionCommand.md
@@ -1,0 +1,86 @@
+# Send-ActionCommand
+```
+
+NAME
+    Send-ActionCommand
+    
+SYNOPSIS
+    Sends a command to the hosting Workflow/Action context.
+    Equivalent to `core.issue(cmd, msg)`/`core.issueCommand(cmd, props, msg)`.
+    
+    
+SYNTAX
+    Send-ActionCommand [-Command] <String> [-Properties] <IDictionary> [[-Message] <String>] [<CommonParameters>]
+    
+    Send-ActionCommand [-Command] <String> [[-Message] <String>] [<CommonParameters>]
+    
+    
+DESCRIPTION
+    Command Format:
+      ::workflow-command parameter1={data},parameter2={data}::{command value}
+    
+
+PARAMETERS
+    -Command <String>
+        The workflow command name.
+        
+        Required?                    true
+        Position?                    1
+        Default value                
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+        
+    -Properties <IDictionary>
+        Properties to add to the command.
+        
+        Required?                    true
+        Position?                    2
+        Default value                
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+        
+    -Message <String>
+        Message to add to the command.
+        
+        Required?                    false
+        Position?                    3
+        Default value                
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+        
+    <CommonParameters>
+        This cmdlet supports the common parameters: Verbose, Debug,
+        ErrorAction, ErrorVariable, WarningAction, WarningVariable,
+        OutBuffer, PipelineVariable, and OutVariable. For more information, see
+        about_CommonParameters (https://go.microsoft.com/fwlink/?LinkID=113216). 
+    
+INPUTS
+    
+OUTPUTS
+    
+    -------------------------- EXAMPLE 1 --------------------------
+    
+    PS>Send-ActionCommand warning 'This is the user warning message'
+    ::warning::This is the user warning message
+    
+    
+    
+    
+    
+    
+    -------------------------- EXAMPLE 2 --------------------------
+    
+    PS>Send-ActionCommand set-secret @{name='mypassword'} 'definitelyNotAPassword!'
+    ::set-secret name=mypassword::definitelyNotAPassword!
+    
+    
+    
+    
+    
+    
+    
+RELATED LINKS
+    https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#about-workflow-commands
+
+```
+

--- a/docs/GitHubActions/Set-ActionCommandEcho.md
+++ b/docs/GitHubActions/Set-ActionCommandEcho.md
@@ -1,0 +1,45 @@
+# Set-ActionCommandEcho
+```
+
+NAME
+    Set-ActionCommandEcho
+    
+SYNOPSIS
+    Enables or disables the echoing of commands into stdout for the rest of the step.
+    Echoing is disabled by default if ACTIONS_STEP_DEBUG is not set.
+    Equivalent of `core.setCommandEcho(enabled)`.
+    
+    
+SYNTAX
+    Set-ActionCommandEcho [-Enabled] <Boolean> [<CommonParameters>]
+    
+    
+DESCRIPTION
+    
+
+PARAMETERS
+    -Enabled <Boolean>
+        $true to enable echoing, $false to disable.
+        
+        Required?                    true
+        Position?                    1
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+        
+    <CommonParameters>
+        This cmdlet supports the common parameters: Verbose, Debug,
+        ErrorAction, ErrorVariable, WarningAction, WarningVariable,
+        OutBuffer, PipelineVariable, and OutVariable. For more information, see
+        about_CommonParameters (https://go.microsoft.com/fwlink/?LinkID=113216). 
+    
+INPUTS
+    
+OUTPUTS
+    
+    
+RELATED LINKS
+    https://github.com/actions/toolkit/blob/7f7e22a9406f546f9084e9eb7a4e541a3563f92b/docs/commands.md#command-echoing
+
+```
+

--- a/docs/GitHubActions/Set-ActionFailed.md
+++ b/docs/GitHubActions/Set-ActionFailed.md
@@ -5,7 +5,9 @@ NAME
     Set-ActionFailed
     
 SYNOPSIS
-    Used as a shortcut for `Write-ActionError` and `exit 1`
+    Sets an action status to failed.
+    When the action exits it will be with an exit code of 1.
+    Equivalent of `core.setFailed(message)`.
     
     
 SYNTAX
@@ -17,6 +19,7 @@ DESCRIPTION
 
 PARAMETERS
     -Message <String>
+        Add issue message.
         
         Required?                    false
         Position?                    1
@@ -36,7 +39,8 @@ OUTPUTS
     
     
 RELATED LINKS
-    https://github.com/actions/toolkit/tree/a6e72497764b1cf53192eb720f551d7f0db3a4b4/packages/core#exit-codes
+    https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#masking-a-value-in-log
+    https://github.com/actions/toolkit/tree/7f7e22a9406f546f9084e9eb7a4e541a3563f92b/packages/core#exit-codes
 
 ```
 

--- a/docs/GitHubActions/Set-ActionOutput.md
+++ b/docs/GitHubActions/Set-ActionOutput.md
@@ -6,10 +6,11 @@ NAME
     
 SYNOPSIS
     Sets the value of an output.
+    Equivalent of `core.setOutput(name, value)`.
     
     
 SYNTAX
-    Set-ActionOutput [-Name] <String> [-Value] <String> [<CommonParameters>]
+    Set-ActionOutput [-Name] <String> [-Value] <Object> [<CommonParameters>]
     
     
 DESCRIPTION
@@ -25,8 +26,8 @@ PARAMETERS
         Accept pipeline input?       false
         Accept wildcard characters?  false
         
-    -Value <String>
-        Value to store.
+    -Value <Object>
+        Value to store. Non-string values will be converted to a string via ConvertTo-Json.
         
         Required?                    true
         Position?                    2
@@ -47,6 +48,7 @@ OUTPUTS
     
 RELATED LINKS
     https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-output-parameter
+    https://github.com/actions/toolkit/tree/7f7e22a9406f546f9084e9eb7a4e541a3563f92b/packages/core#inputsoutputs
 
 ```
 

--- a/docs/GitHubActions/Write-ActionDebug.md
+++ b/docs/GitHubActions/Write-ActionDebug.md
@@ -6,6 +6,7 @@ NAME
     
 SYNOPSIS
     Writes debug message to user log.
+    Equivalent of `core.debug(message)`.
     
     
 SYNTAX
@@ -17,7 +18,7 @@ DESCRIPTION
 
 PARAMETERS
     -Message <String>
-        Debug message
+        Debug message.
         
         Required?                    false
         Position?                    1
@@ -38,6 +39,7 @@ OUTPUTS
     
 RELATED LINKS
     https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-a-debug-message
+    https://github.com/actions/toolkit/tree/7f7e22a9406f546f9084e9eb7a4e541a3563f92b/packages/core#logging
 
 ```
 

--- a/docs/GitHubActions/Write-ActionError.md
+++ b/docs/GitHubActions/Write-ActionError.md
@@ -6,10 +6,17 @@ NAME
     
 SYNOPSIS
     Adds an error issue.
+    Equivalent of `core.error(message)`.
     
     
 SYNTAX
-    Write-ActionError [[-Message] <String>] [[-File] <String>] [[-Line] <Int32>] [[-Col] <Int32>] [<CommonParameters>]
+    Write-ActionError [[-Message] <String>] [-File] <String> [-Line] <Int32> [-Column] <Int32> [<CommonParameters>]
+    
+    Write-ActionError [[-Message] <String>] [-File] <String> [-Line] <Int32> [<CommonParameters>]
+    
+    Write-ActionError [[-Message] <String>] [-File] <String> [<CommonParameters>]
+    
+    Write-ActionError [[-Message] <String>] [<CommonParameters>]
     
     
 DESCRIPTION
@@ -17,7 +24,7 @@ DESCRIPTION
 
 PARAMETERS
     -Message <String>
-        Error issue message
+        Error issue message.
         
         Required?                    false
         Position?                    1
@@ -26,26 +33,29 @@ PARAMETERS
         Accept wildcard characters?  false
         
     -File <String>
+        Filename where the issue occured.
         
-        Required?                    false
+        Required?                    true
         Position?                    2
         Default value                
         Accept pipeline input?       false
         Accept wildcard characters?  false
         
     -Line <Int32>
+        Line number of the File where the issue occured.
         
-        Required?                    false
+        Required?                    true
         Position?                    3
-        Default value                -1
+        Default value                0
         Accept pipeline input?       false
         Accept wildcard characters?  false
         
-    -Col <Int32>
+    -Column <Int32>
+        Column number in Line in File where the issue occured.
         
-        Required?                    false
+        Required?                    true
         Position?                    4
-        Default value                -1
+        Default value                0
         Accept pipeline input?       false
         Accept wildcard characters?  false
         
@@ -59,9 +69,16 @@ INPUTS
     
 OUTPUTS
     
+NOTES
+    
+    
+        File, Line and Column parameters are supported by the actual workflow command,
+        but not available in `@actions/core` package.
+    
     
 RELATED LINKS
     https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-error-message
+    https://github.com/actions/toolkit/tree/7f7e22a9406f546f9084e9eb7a4e541a3563f92b/packages/core#logging
 
 ```
 

--- a/docs/GitHubActions/Write-ActionInfo.md
+++ b/docs/GitHubActions/Write-ActionInfo.md
@@ -6,6 +6,8 @@ NAME
     
 SYNOPSIS
     Writes info to log with console.log.
+    Equivalent of `core.info(message)`.
+    Forwards to Write-Host.
     
     
 SYNTAX
@@ -17,7 +19,7 @@ DESCRIPTION
 
 PARAMETERS
     -Message <String>
-        Info message
+        Info message.
         
         Required?                    false
         Position?                    1
@@ -37,6 +39,7 @@ OUTPUTS
     
     
 RELATED LINKS
+    https://github.com/actions/toolkit/tree/7f7e22a9406f546f9084e9eb7a4e541a3563f92b/packages/core#logging
 
 ```
 

--- a/docs/GitHubActions/Write-ActionWarning.md
+++ b/docs/GitHubActions/Write-ActionWarning.md
@@ -6,10 +6,17 @@ NAME
     
 SYNOPSIS
     Adds a warning issue.
+    Equivalent of `core.warning(message)`.
     
     
 SYNTAX
-    Write-ActionWarning [[-Message] <String>] [[-File] <String>] [[-Line] <Int32>] [[-Col] <Int32>] [<CommonParameters>]
+    Write-ActionWarning [[-Message] <String>] [-File] <String> [-Line] <Int32> [-Column] <Int32> [<CommonParameters>]
+    
+    Write-ActionWarning [[-Message] <String>] [-File] <String> [-Line] <Int32> [<CommonParameters>]
+    
+    Write-ActionWarning [[-Message] <String>] [-File] <String> [<CommonParameters>]
+    
+    Write-ActionWarning [[-Message] <String>] [<CommonParameters>]
     
     
 DESCRIPTION
@@ -17,7 +24,7 @@ DESCRIPTION
 
 PARAMETERS
     -Message <String>
-        Warning issue message
+        Warning issue message.
         
         Required?                    false
         Position?                    1
@@ -26,26 +33,29 @@ PARAMETERS
         Accept wildcard characters?  false
         
     -File <String>
+        Filename where the issue occured.
         
-        Required?                    false
+        Required?                    true
         Position?                    2
         Default value                
         Accept pipeline input?       false
         Accept wildcard characters?  false
         
     -Line <Int32>
+        Line number of the File where the issue occured.
         
-        Required?                    false
+        Required?                    true
         Position?                    3
-        Default value                -1
+        Default value                0
         Accept pipeline input?       false
         Accept wildcard characters?  false
         
-    -Col <Int32>
+    -Column <Int32>
+        Column number in Line in File where the issue occured.
         
-        Required?                    false
+        Required?                    true
         Position?                    4
-        Default value                -1
+        Default value                0
         Accept pipeline input?       false
         Accept wildcard characters?  false
         
@@ -59,9 +69,16 @@ INPUTS
     
 OUTPUTS
     
+NOTES
+    
+    
+        File, Line and Column parameters are supported by the actual workflow command,
+        but not available in `@actions/core` package.
+    
     
 RELATED LINKS
     https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-a-warning-message
+    https://github.com/actions/toolkit/tree/7f7e22a9406f546f9084e9eb7a4e541a3563f92b/packages/core#logging
 
 ```
 


### PR DESCRIPTION
@ebekker I tried my best to port in my module in the form I have in my repo. There's a lot of changes, and still a lot to do. Please take a look and tell me what are the next steps.

I see the following:
- I use default vs-code format document on ps1 files which differs from original formatting (introduces unnecessary noise)
- `Set-ActionFailed` definitely requires discussion 😅 your implementation doesn't work for my use case in `pwsh-script`, but mine doesn't work in general case; I'd want to be able to still "catch" the error message and set it as an output. Ideas?
- My `Add-ActionSecret` follows the `core` toolkit naming (`core.addSecret`)
- My `Invoke-ActionGroup` follows the `core` toolkit naming (`core.group`)
- In `build-docs.ps1`:
  - I made the script executable
  - I used script block instead of string to have IntelliSense available in it
  - I purge the directory before writing files
- I added a couple new commands:
  - `Get-ActionIsDebug`
  - `Invoke-ActionNoCommandsBlock`
  - `Send-ActionCommand` (surfaced, as I feel it's useful, new commands are added almost constantly)
  - `Set-ActionCommandEcho`
- Replaced tests with my own; this will probably need much more work to merge both suites.